### PR TITLE
Add support for the image-tag-parameter-plugin in the declarative pipeline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = false
+max_line_length = 128
+tab_width = 4

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ work/
 \.settings/
 \.vscode/
 target/
+
+# IntelliJ
+.idea/
+*.iml
+out/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ It use the Docker **Registry HTTP API V2** to list tags availaible for an image.
 
 ![Image Selection](img/screen03.png)
 
+## Use in Declarative Pipeline
+```groovy
+pipeline {
+  agent any
+
+  parameters {
+    imageTag credentialId: '', description: '', filter: 'lts.*', image: 'jenkins/jenkins', name: 'DOCKER_IMAGE', registry: 'https://registry-1.docker.io'
+  }
+
+  stages {
+    stage('Test') {
+      steps {
+        echo "$DOCKER_IMAGE"
+      }
+    }
+  }
+}
+```
+
 ## how to build the Jenkins Plugin
  
 ### Install skdman

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>3.50</version>
-        <relativePath />
+        <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>image-tag-parameter</artifactId>
@@ -22,20 +23,20 @@
             <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
-      <developers>
-    <developer>
-      <id>maduma</id>
-      <name>Stéphane Nsakala</name>
-      <email>maduma@pt.lu</email>
-    </developer>
-  </developers>
+    <developers>
+        <developer>
+            <id>maduma</id>
+            <name>Stéphane Nsakala</name>
+            <email>maduma@pt.lu</email>
+        </developer>
+    </developers>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
         <version>3.50</version>
         <relativePath/>
     </parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>image-tag-parameter</artifactId>
     <version>1.3-SNAPSHOT</version>
     <packaging>hpi</packaging>

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -108,6 +109,7 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
         return req.bindJSON(StringParameterValue.class, jo);
     }
 
+    @Symbol("imageTag")
     @Extension
     public static class DescriptorImpl extends ParameterDescriptor {
 


### PR DESCRIPTION
This PR aims to allow the use of the image-tag-parameter-plugin in the declarative pipeline syntax.
eg.:
```
pipeline {
  agent any

  parameters {
    imageTag credentialId: '', description: '', filter: 'lts.*', image: 'jenkins/jenkins', name: 'DOCKER_IMAGE', registry: 'https://registry-1.docker.io'
  }

  stages {
    stage('Test') {
      steps {
        echo "$DOCKER_IMAGE"
      }
    }
  }
}
```

## Additional commits:
* I added IntelliJ files and folders to the gitignore since I use IntelliJ to develop Java 
* I added a .editorconfig so keeping file formatting unified is easier for all IDEs that support it (VsCode, IntelliJ, etc.)
* After I added the .editorconf I reformatted the pom (and removed the redundant groupId)
* I added a section in the readme showcasing the enabled functionality

---

Hope this PR format is ok for this repo! If there is anything I need to fix, do, add or remove let me know and I shall try to get it done ASAP.

Regards 😉