### PR TITLE
Remove left margin

### DIFF
--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
@@ -10,7 +10,7 @@
             <input type="hidden" name="description" value="${it.description}" />
 
 
-            <select name="value" style="width:300px; margin-left: 15px;">
+            <select name="value" style="width:300px;">
                 <j:forEach var="aTag" items="${it.tags}" varStatus="loop">
                     <j:choose>
                         <option value="${aTag}">${aTag}</option>


### PR DESCRIPTION
Hello!
I found out that the image-tag-parameter-plugin has different pagination than other plugins. I would like to remove that if there is no particular reasons to have it. 

See example below: 
<img width="757" alt="modified" src="https://user-images.githubusercontent.com/20466436/84619115-dfdc0d00-aedc-11ea-9ca0-554b7aea2e0b.png">

Signed-off-by: Jasstkn <jasssstkn@yahoo.com>