### PR TITLE
Default Value Support and Additional envVars for TagOnly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = false
+max_line_length = 128
+tab_width = 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,8 @@
 - v1.3   For compatibility with OAuth 2.0, we will also accept token under the name access_token
 - v1.4   Compatibility with Pipeline
 - v1.5   Fix pagination in HTML for display
+
+Snapshot
+- v1.6
+    * Add support for default value
+    * Add additional envVar export to get imageTag without image name

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ It use the Docker **Registry HTTP API V2** to list tags availaible for an image.
 
 ![Image Selection](img/screen03.png)
 
-## Definition in Pipeline
+## Usage
+
+### Definition in Freestyle / Pipeline UI
+This is basically showcased in the above [screenshots](#screenshots) :wink:
+
+### Definition in Pipeline
 ```groovy
 pipeline {
   agent any
@@ -32,6 +37,14 @@ pipeline {
   }
 }
 ```
+
+### Exposed Environment Variables (and params, since version 1.6) 
+Based on default Jenkins behaviour you can use `params.imageTagParameterName` to access the value of `imageName:imageTag`,
+but since you most of the time only need the image tag by itself the plugin also exports some additional environment variables.
+
+* **$imageTagParameterName_TAG** (or *env.imageTagParameterName_TAG*) contains only the tag value without the image name
+* **$imageTagParameterName_IMAGE** (or *env.imageTagParameterName_IMAGE*) contains only the name of the image without the tag
+
 
 ## how to build the Jenkins Plugin
  

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
@@ -48,9 +48,9 @@ public class ImageTag {
         if (m.find()) {
             rtn[0] = m.group(1);
             rtn[1] = m.group(2);
-            logger.info(() -> "realm:" + rtn[0] + ": service:" + rtn[1] + ":");
+            logger.info("realm:" + rtn[0] + ": service:" + rtn[1] + ":");
         } else {
-            logger.warning(() -> "No AuthService available from " + url);
+            logger.warning("No AuthService available from " + url);
         }
         return rtn;
     }

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
@@ -1,18 +1,14 @@
 package io.jenkins.plugins.luxair;
 
+import kong.unirest.*;
+import kong.unirest.json.JSONObject;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import kong.unirest.GetRequest;
-import kong.unirest.HttpResponse;
-import kong.unirest.Interceptor;
-import kong.unirest.JsonNode;
-import kong.unirest.Unirest;
-import kong.unirest.json.JSONObject;
 
 
 public class ImageTag {
@@ -27,6 +23,7 @@ public class ImageTag {
         List<String> tags = getImageTagsFromRegistry(image, registry, token);
         return tags.stream().filter(tag -> tag.matches(filter))
             .map(tag -> image + ":" + tag)
+            .sorted()
             .collect(Collectors.toList());
     }
 
@@ -113,7 +110,6 @@ public class ImageTag {
         }
         Unirest.shutDown();
 
-        Collections.sort(tags, Collections.reverseOrder());
         return tags;
     }
 }

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
@@ -16,6 +16,10 @@ public class ImageTag {
     private static final Logger logger = Logger.getLogger(ImageTag.class.getName());
     private static final Interceptor errorInterceptor = new ErrorInterceptor();
 
+    private ImageTag() {
+        throw new IllegalStateException("Utility class");
+    }
+
     public static List<String> getTags(String image, String registry, String filter, String user, String password) {
 
         String[] authService = getAuthService(registry);
@@ -45,9 +49,9 @@ public class ImageTag {
         if (m.find()) {
             rtn[0] = m.group(1);
             rtn[1] = m.group(2);
-            logger.info("realm:" + rtn[0] + ": service:" + rtn[1] + ":");
+            logger.info(() -> "realm:" + rtn[0] + ": service:" + rtn[1] + ":");
         } else {
-            logger.warning("No AuthService available from " + url);
+            logger.warning(() -> "No AuthService available from " + url);
         }
         return rtn;
     }

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
@@ -4,6 +4,7 @@ import kong.unirest.*;
 import kong.unirest.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -26,7 +27,7 @@ public class ImageTag {
         String token = getAuthToken(authService, image, user, password);
         List<String> tags = getImageTagsFromRegistry(image, registry, token);
         return tags.stream().filter(tag -> tag.matches(filter))
-            .sorted()
+            .sorted(Collections.reverseOrder())
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
@@ -26,7 +26,6 @@ public class ImageTag {
         String token = getAuthToken(authService, image, user, password);
         List<String> tags = getImageTagsFromRegistry(image, registry, token);
         return tags.stream().filter(tag -> tag.matches(filter))
-            .map(tag -> image + ":" + tag)
             .sorted()
             .collect(Collectors.toList());
     }

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -6,6 +6,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import hudson.Extension;
 import hudson.model.Item;
+import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
 import hudson.model.SimpleParameterDefinition;
 import hudson.security.ACL;
@@ -27,20 +28,24 @@ import java.util.logging.Logger;
 
 public class ImageTagParameterDefinition extends SimpleParameterDefinition {
 
+    private static final long serialVersionUID = 3938123092372L;
     private static final Logger logger = Logger.getLogger(ImageTagParameterDefinition.class.getName());
     private static final ImageTagParameterConfiguration config = ImageTagParameterConfiguration.get();
 
     private final String image;
     private final String registry;
     private final String filter;
+    private final String defaultTag;
     private final String credentialId;
 
     @DataBoundConstructor
-    public ImageTagParameterDefinition(String name, String description, String image, String registry, String filter, String credentialId) {
+    public ImageTagParameterDefinition(String name, String description, String defaultTag,
+                                       String image, String registry, String filter, String credentialId) {
         super(name, description);
         this.image = image;
         this.registry = StringUtil.isNotNullOrEmpty(registry) ? registry : config.getDefaultRegistry();
         this.filter = StringUtil.isNotNullOrEmpty(filter) ? filter : ".*";
+        this.defaultTag = StringUtil.isNotNullOrEmpty(defaultTag) ? defaultTag : "";
         this.credentialId = StringUtil.isNotNullOrEmpty(credentialId) ? credentialId : "";
     }
 
@@ -54,6 +59,10 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
 
     public String getFilter() {
         return filter;
+    }
+
+    public String getDefaultTag() {
+        return defaultTag;
     }
 
     public String getCredentialId() {
@@ -96,7 +105,15 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
         return null;
     }
 
-    private static final long serialVersionUID = 3938123092372L;
+    @Override
+    public ParameterDefinition copyWithDefaultValue(ParameterValue defaultValue) {
+        if (defaultValue instanceof ImageTagParameterValue) {
+            ImageTagParameterValue value = (ImageTagParameterValue) defaultValue;
+            return new ImageTagParameterDefinition(getName(), getDescription(), value.getImageTag(),
+                getImage(), getRegistry(), getFilter(), getCredentialId());
+        }
+        return this;
+    }
 
     @Override
     public ParameterValue createValue(String value) {

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -19,6 +19,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
@@ -88,7 +89,7 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
                     }
                 }
             }
-            logger.warning("Cannot find credential for :" + credentialId + ":");
+            logger.warning(() -> "Cannot find credential for :" + credentialId + ":");
         } else {
             logger.info("CredentialId is empty");
         }
@@ -112,6 +113,7 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
     public static class DescriptorImpl extends ParameterDescriptor {
 
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "Image Tag Parameter";
         }        

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -8,7 +8,6 @@ import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.ParameterValue;
 import hudson.model.SimpleParameterDefinition;
-import hudson.model.StringParameterValue;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.luxair.util.StringUtil;
@@ -100,12 +99,12 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
 
     @Override
     public ParameterValue createValue(String value) {
-        return new StringParameterValue(getName(), value, getDescription());
+        return new ImageTagParameterValue(getName(), value, getDescription());
     }
 
     @Override
     public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
-        return req.bindJSON(StringParameterValue.class, jo);
+        return req.bindJSON(ImageTagParameterValue.class, jo);
     }
 
     @Symbol("imageTag")

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -100,7 +100,7 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
 
     @Override
     public ParameterValue createValue(String value) {
-        return new ImageTagParameterValue(getName(), value, getDescription());
+        return new ImageTagParameterValue(getName(), image, value, getDescription());
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -98,7 +98,7 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
                     }
                 }
             }
-            logger.warning(() -> "Cannot find credential for :" + credentialId + ":");
+            logger.warning("Cannot find credential for :" + credentialId + ":");
         } else {
             logger.info("CredentialId is empty");
         }

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterValue.java
@@ -1,0 +1,93 @@
+package io.jenkins.plugins.luxair;
+
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.ParameterValue;
+import hudson.model.Run;
+import hudson.util.VariableResolver;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.export.Exported;
+
+import java.util.Locale;
+
+/**
+ * {@link ParameterValue} created from {@link ImageTagParameterDefinition}.
+ */
+public class ImageTagParameterValue extends ParameterValue {
+    @Exported(visibility = 4)
+    @Restricted(NoExternalUse.class)
+    public String value;
+
+    @DataBoundConstructor
+    public ImageTagParameterValue(String name, String value) {
+        this(name, value, null);
+    }
+
+    public ImageTagParameterValue(String name, String value, String description) {
+        super(name, description);
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Exposes the name/value as an environment variable.
+     */
+    @Override
+    public void buildEnvironment(Run<?, ?> build, EnvVars env) {
+        // exposes ImageName
+        env.put(String.format("%s_IMAGE", name), value.split(":")[0]);
+        env.put(String.format("%s_IMAGE", name).toUpperCase(Locale.ENGLISH), value.split(":")[0]); // backward compatibility pre 1.345
+
+        // exposes ImageTag
+        env.put(String.format("%s_TAG", name), value.split(":")[1]);
+        env.put(String.format("%s_TAG", name).toUpperCase(Locale.ENGLISH), value.split(":")[1]); // backward compatibility pre 1.345
+
+        // exposes ImageName:ImageTag (aka. value)
+        env.put(name, value);
+        env.put(name.toUpperCase(Locale.ENGLISH), value); // backward compatibility pre 1.345
+    }
+
+    @Override
+    public VariableResolver<String> createVariableResolver(AbstractBuild<?, ?> build) {
+        return new VariableResolver<String>() {
+            public String resolve(String name) {
+                return ImageTagParameterValue.this.name.equals(name) ? value : null;
+            }
+        };
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        ImageTagParameterValue that = (ImageTagParameterValue) o;
+
+        return value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "(ImageTagParameterValue) " + getName() + "='" + value + "'";
+    }
+
+    @Override
+    public String getShortDescription() {
+        return name + '=' + value;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterValue.java
@@ -55,11 +55,7 @@ public class ImageTagParameterValue extends ParameterValue {
 
     @Override
     public VariableResolver<String> createVariableResolver(AbstractBuild<?, ?> build) {
-        return new VariableResolver<String>() {
-            public String resolve(String name) {
-                return ImageTagParameterValue.this.name.equals(name) ? value : null;
-            }
-        };
+        return name -> ImageTagParameterValue.this.name.equals(name) ? value : null;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterValue.java
@@ -18,16 +18,26 @@ import java.util.Locale;
 public class ImageTagParameterValue extends ParameterValue {
     @Exported(visibility = 4)
     @Restricted(NoExternalUse.class)
+    public String imageName;
+
+    @Exported(visibility = 4)
+    @Restricted(NoExternalUse.class)
+    public String imageTag;
+
+    @Exported(visibility = 4)
+    @Restricted(NoExternalUse.class)
     public String value;
 
     @DataBoundConstructor
-    public ImageTagParameterValue(String name, String value) {
-        this(name, value, null);
+    public ImageTagParameterValue(String name, String imageName, String imageTag) {
+        this(name, imageName, imageTag, null);
     }
 
-    public ImageTagParameterValue(String name, String value, String description) {
+    public ImageTagParameterValue(String name, String imageName, String imageTag, String description) {
         super(name, description);
-        this.value = value;
+        this.imageName = imageName;
+        this.imageTag = imageTag;
+        this.value = String.format("%s:%s", imageName, imageTag);
     }
 
     @Override
@@ -41,12 +51,12 @@ public class ImageTagParameterValue extends ParameterValue {
     @Override
     public void buildEnvironment(Run<?, ?> build, EnvVars env) {
         // exposes ImageName
-        env.put(String.format("%s_IMAGE", name), value.split(":")[0]);
-        env.put(String.format("%s_IMAGE", name).toUpperCase(Locale.ENGLISH), value.split(":")[0]); // backward compatibility pre 1.345
+        env.put(String.format("%s_IMAGE", name), imageName);
+        env.put(String.format("%s_IMAGE", name).toUpperCase(Locale.ENGLISH), imageName); // backward compatibility pre 1.345
 
         // exposes ImageTag
-        env.put(String.format("%s_TAG", name), value.split(":")[1]);
-        env.put(String.format("%s_TAG", name).toUpperCase(Locale.ENGLISH), value.split(":")[1]); // backward compatibility pre 1.345
+        env.put(String.format("%s_TAG", name), imageTag);
+        env.put(String.format("%s_TAG", name).toUpperCase(Locale.ENGLISH), imageTag); // backward compatibility pre 1.345
 
         // exposes ImageName:ImageTag (aka. value)
         env.put(name, value);

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterValue.java
@@ -40,6 +40,14 @@ public class ImageTagParameterValue extends ParameterValue {
         this.value = String.format("%s:%s", imageName, imageTag);
     }
 
+    public String getImageName() {
+        return imageName;
+    }
+
+    public String getImageTag() {
+        return imageTag;
+    }
+
     @Override
     public String getValue() {
         return value;

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterConfiguration/config.jelly
@@ -3,7 +3,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:section title="${%Image Tag Parameter Plugin}">
         <f:entry field="defaultRegistry" title="${%Default Registry}">
-            <f:textbox/>
+            <f:textbox />
         </f:entry>
     </f:section>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/config.jelly
@@ -3,27 +3,27 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
     <f:entry title="${%Name}" field="name">
-        <f:textbox default="DOCKER_IMAGE"/>
+        <f:textbox default="DOCKER_IMAGE" />
     </f:entry>
 
     <f:entry title="${%Image Name}" field="image">
-        <f:textbox default=""/>
+        <f:textbox default="" />
     </f:entry>
 
     <f:entry title="${%Tag Filter Pattern}" field="filter">
-        <f:textbox default=".*"/>
+        <f:textbox default=".*" />
     </f:entry>
 
     <f:entry title="${%Default Tag}" field="defaultTag">
-        <f:textbox default=""/>
+        <f:textbox default="" />
     </f:entry>
 
     <f:entry title="${%Regitry URL}" field="registry">
-        <f:textbox default="${descriptor.defaultRegistry()}"/>
+        <f:textbox default="${descriptor.defaultRegistry()}" />
     </f:entry>
 
     <f:entry title="Description" field="description">
-        <f:textarea/>
+        <f:textarea />
     </f:entry>
 
     <f:entry title="${%Registry Credential ID}" field="credentialId">

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/config.jelly
@@ -1,28 +1,32 @@
 <!-- this is the page fragment displayed to set up a job -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
     <f:entry title="${%Name}" field="name">
-		<f:textbox default="DOCKER_IMAGE" />
-	</f:entry>
-
-    <f:entry title="${%Image Name}" field="image">
-		<f:textbox default="" />
-	</f:entry>
-
-    <f:entry title="${%Tag Filter Pattern}" field="filter">
-		<f:textbox default=".*" />
-	</f:entry>
-
-    <f:entry title="${%Regitry URL}" field="registry">
-		<f:textbox default="${descriptor.defaultRegistry()}"/>
-	</f:entry>
-
-	 <f:entry title="Description" field="description">
-        <f:textarea />
+        <f:textbox default="DOCKER_IMAGE"/>
     </f:entry>
 
-	<f:entry title="${%Registry Credential ID}" field="credentialId">
+    <f:entry title="${%Image Name}" field="image">
+        <f:textbox default=""/>
+    </f:entry>
+
+    <f:entry title="${%Tag Filter Pattern}" field="filter">
+        <f:textbox default=".*"/>
+    </f:entry>
+
+    <f:entry title="${%Default Tag}" field="defaultTag">
+        <f:textbox default=""/>
+    </f:entry>
+
+    <f:entry title="${%Regitry URL}" field="registry">
+        <f:textbox default="${descriptor.defaultRegistry()}"/>
+    </f:entry>
+
+    <f:entry title="Description" field="description">
+        <f:textarea/>
+    </f:entry>
+
+    <f:entry title="${%Registry Credential ID}" field="credentialId">
 		<c:select />
 	</f:entry>
 

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/help-defaultTag.html
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/help-defaultTag.html
@@ -1,3 +1,4 @@
 <div>
-    Specify a tag value that should get preselected selected as default (e.g.: v1.0 for the image myImage:v1.0)
+    Specify a tag value that should get preselected selected as default (e.g.: v1.0 for the image myImage:v1.0)<br/>
+    NOTE: the defaultTag will get string compared to the fetched tags and if no equal exists will get ignored
 </div>

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/help-defaultTag.html
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/help-defaultTag.html
@@ -1,0 +1,3 @@
+<div>
+    Specify a tag value that should get preselected selected as default (e.g.: v1.0 for the image myImage:v1.0)
+</div>

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
@@ -13,7 +13,7 @@
             <select name="imageTag" style="width:300px;">
                 <j:forEach var="aTag" items="${it.tags}" varStatus="loop">
                     <j:choose>
-                        <option value="${aTag}">${aTag}</option>
+                        <option value="${aTag}">${it.image}:${aTag}</option>
                     </j:choose>
                 </j:forEach>
             </select>

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
@@ -9,7 +9,7 @@
             <input type="hidden" name="description" value="${it.description}" />
             <input type="hidden" name="imageName" value="${it.image}" />
 
-            <select name="imageTag" style="width:300px;">
+            <select name="imageTag" style="min-width:18rem;">
                 <j:forEach var="aTag" items="${it.tags}" varStatus="loop">
                     <j:choose>
                         <j:when test="${aTag.equals(it.defaultTag)}">

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
@@ -1,19 +1,18 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
-         xmlns:f="/lib/form"
->
+         xmlns:f="/lib/form">
 
     <f:entry title="${it.name}" description="${it.description}">
         <!-- this div is required because of ParametersDefinitionProperty.java#117 -->
         <div name="parameter" description="${it.description}">
-            <input type="hidden" name="name" value="${it.name}"/>
-            <input type="hidden" name="description" value="${it.description}"/>
-            <input type="hidden" name="imageName" value="${it.image}"/>
+            <input type="hidden" name="name" value="${it.name}" />
+            <input type="hidden" name="description" value="${it.description}" />
+            <input type="hidden" name="imageName" value="${it.image}" />
 
             <select name="imageTag" style="width:300px;">
                 <j:forEach var="aTag" items="${it.tags}" varStatus="loop">
                     <j:choose>
-                        <j:when test="${aTag.contains(it.defaultTag)}">
+                        <j:when test="${aTag.equals(it.defaultTag)}">
                             <option value="${aTag}" selected="selected">${it.image}:${aTag}</option>
                         </j:when>
                         <j:otherwise>

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
@@ -8,9 +8,9 @@
         <div name="parameter" description="${it.description}">
             <input type="hidden" name="name" value="${it.name}" />
             <input type="hidden" name="description" value="${it.description}" />
+            <input type="hidden" name="imageName" value="${it.image}" />
 
-
-            <select name="value" style="width:300px;">
+            <select name="imageTag" style="width:300px;">
                 <j:forEach var="aTag" items="${it.tags}" varStatus="loop">
                     <j:choose>
                         <option value="${aTag}">${aTag}</option>

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
@@ -1,19 +1,24 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
-         xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form"
+>
 
     <f:entry title="${it.name}" description="${it.description}">
         <!-- this div is required because of ParametersDefinitionProperty.java#117 -->
         <div name="parameter" description="${it.description}">
-            <input type="hidden" name="name" value="${it.name}" />
-            <input type="hidden" name="description" value="${it.description}" />
-            <input type="hidden" name="imageName" value="${it.image}" />
+            <input type="hidden" name="name" value="${it.name}"/>
+            <input type="hidden" name="description" value="${it.description}"/>
+            <input type="hidden" name="imageName" value="${it.image}"/>
 
             <select name="imageTag" style="width:300px;">
                 <j:forEach var="aTag" items="${it.tags}" varStatus="loop">
                     <j:choose>
-                        <option value="${aTag}">${it.image}:${aTag}</option>
+                        <j:when test="${aTag.contains(it.defaultTag)}">
+                            <option value="${aTag}" selected="selected">${it.image}:${aTag}</option>
+                        </j:when>
+                        <j:otherwise>
+                            <option value="${aTag}">${it.image}:${aTag}</option>
+                        </j:otherwise>
                     </j:choose>
                 </j:forEach>
             </select>

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterValue/value.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterValue/value.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+        <j:set var="escapeEntryTitleAndDescription" value="false"/>
+        <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
+		<f:textbox name="value" value="${it.value}" readonly="true" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterValue/value.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterValue/value.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-        <j:set var="escapeEntryTitleAndDescription" value="false"/>
+        <j:set var="escapeEntryTitleAndDescription" value="false" />
         <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
 		<f:textbox name="value" value="${it.value}" readonly="true" />
 	</f:entry>


### PR DESCRIPTION
## Summary
This PR is an alternative to [image-tag-parameter-plugin#4](https://github.com/jenkinsci/image-tag-parameter-plugin/pull/4).
It adds the support for the user to set a default tag value that should get preselected if it exists in the fetched tags list.
Additionally, this PR adds the support do directly access the selected tag without the image name by exposing it as an additional environment variable (see readme changes for how to access this).

## Tests
Jenkins 2.222.1 and 2.235.1 (aka LTS)
additionally checked support for [rebuild-plugin](https://github.com/jenkinsci/rebuild-plugin) support.

---

Should there be anything that prevents this from a merge let me know and ill try to fix it ASAP.

And finally, a big thank you to @Reuuke for allowing me to use some of their original PR! :beers: 