### PR TITLE
Hotfix - For non resetting Error Message

### DIFF
--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -11,8 +11,8 @@ import hudson.model.ParameterValue;
 import hudson.model.SimpleParameterDefinition;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
-import io.jenkins.plugins.luxair.model.ErrorContainer;
 import io.jenkins.plugins.luxair.model.Ordering;
+import io.jenkins.plugins.luxair.model.ResultContainer;
 import io.jenkins.plugins.luxair.util.StringUtil;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -122,15 +122,15 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
             password = credential.getPassword().getPlainText();
         }
 
-        ErrorContainer<List<String>> errorContainer = ImageTag.getTags(image, registry, filter, user, password, tagOrder);
-        Optional<String> optionalErrorMsg = errorContainer.getErrorMsg();
+        ResultContainer<List<String>> resultContainer = ImageTag.getTags(image, registry, filter, user, password, tagOrder);
+        Optional<String> optionalErrorMsg = resultContainer.getErrorMsg();
         if (optionalErrorMsg.isPresent()) {
             setErrorMsg(optionalErrorMsg.get());
         } else {
             setErrorMsg("");
         }
 
-        return errorContainer.getValue();
+        return resultContainer.getValue();
     }
 
     private StandardUsernamePasswordCredentials findCredential(String credentialId) {

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -22,6 +22,7 @@ import org.kohsuke.stapler.*;
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 
@@ -122,7 +123,12 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
         }
 
         ErrorContainer<List<String>> errorContainer = ImageTag.getTags(image, registry, filter, user, password, tagOrder);
-        errorContainer.getErrorMsg().ifPresent(this::setErrorMsg);
+        Optional<String> optionalErrorMsg = errorContainer.getErrorMsg();
+        if (optionalErrorMsg.isPresent()) {
+            setErrorMsg(optionalErrorMsg.get());
+        } else {
+            setErrorMsg("");
+        }
 
         return errorContainer.getValue();
     }

--- a/src/main/java/io/jenkins/plugins/luxair/model/ResultContainer.java
+++ b/src/main/java/io/jenkins/plugins/luxair/model/ResultContainer.java
@@ -2,11 +2,11 @@ package io.jenkins.plugins.luxair.model;
 
 import java.util.Optional;
 
-public class ErrorContainer<V> {
+public class ResultContainer<V> {
     private String errorMsg = null;
     private V value;
 
-    public ErrorContainer(V defaultValue) {
+    public ResultContainer(V defaultValue) {
         this.value = defaultValue;
     }
 


### PR DESCRIPTION
This Error was a regression introduced with #7. The error message wasn't reset if an errorMsg was set due to an error, even if the configuration got fixed or the error was cleared.

This also renames the ErrorContainer to ResultContainer for clarity, as the class is meant to capsule a Result and only optionally contains an error message if fetching the result failed.