### PR TITLE
Ignore case sensitivity on authentication type checking

### DIFF
--- a/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
@@ -93,14 +93,14 @@ public class ImageTag {
             type = typeMatcher.group(1);
         }
 
-        if (type.equals("Basic")) {
+        if (type.equalsIgnoreCase("Basic")) {
             rtn[0] = "Basic";
             logger.info("AuthService: type=Basic");
 
             return rtn;
         }
 
-        if (type.equals("Bearer")) {
+        if (type.equalsIgnoreCase("Bearer")) {
             String pattern = "Bearer realm=\"(\\S+)\",service=\"(\\S+)\"";
             Matcher m = Pattern.compile(pattern).matcher(headerValue);
             if (m.find()) {


### PR DESCRIPTION
e.g. Sonatype Nexus returns in header: `BASIC realm="Sonatype Nexus Repository Manager"`