### PR TITLE
Update: Release Drafter config (depends on #14)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"
+      time: "10:00"
     ignore:
       - dependency_name: "org.jenkins-ci.main:jenkins-core"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
       time: "10:00"
     ignore:
       - dependency-name: "org.jenkins-ci.main:jenkins-core"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "10:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "java:maven"
+  - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
       day: "wednesday"
       time: "10:00"
     ignore:
-      - dependency_name: "org.jenkins-ci.main:jenkins-core"
+      - dependency-name: "org.jenkins-ci.main:jenkins-core"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,12 +6,16 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '*'
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v5.11.0
+        with:
+          publish: startsWith(github.ref, "refs/tags")
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,5 +1,6 @@
 # Automates creation of Release Drafts using Release Drafter
 # More Info: https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+name: Release Drafter
 
 on:
   push:


### PR DESCRIPTION
This PR names the Release Drafter Action workflow and sets it up to auto publish a new GitHub Release on a new git tag.

It also adds to the Dependabot cofing a step to check for GitHub-Actions versions.

**WARNING** this PR is based on the changes I proposed with #14 