### PR TITLE
Added boolean configuration item to disable verification of certificates talking to the registry

### DIFF
--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterConfiguration.java
@@ -29,6 +29,7 @@ public class ImageTagParameterConfiguration extends GlobalConfiguration {
     private String defaultRegistry = DEFAULT_REGISTRY;
     private String defaultCredentialId = "";
     private Ordering defaultTagOrdering = Ordering.NATURAL;
+    private Boolean defaultVerifySsl = true;
 
     public ImageTagParameterConfiguration() {
         load();
@@ -46,6 +47,8 @@ public class ImageTagParameterConfiguration extends GlobalConfiguration {
         return defaultTagOrdering != null ? defaultTagOrdering : Ordering.NATURAL;
     }
 
+    public Boolean getDefaultVerifySsl() { return defaultVerifySsl; }
+
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) {
         if (json.has("defaultRegistry")) {
@@ -59,6 +62,10 @@ public class ImageTagParameterConfiguration extends GlobalConfiguration {
         if (json.has("defaultTagOrdering")) {
             this.defaultTagOrdering = Ordering.valueOf(json.getString("defaultTagOrdering"));
             logger.fine("Changed default tag ordering to: " + defaultTagOrdering);
+        }
+        if (json.has("defaultVerifySsl")) {
+            this.defaultVerifySsl = json.getBoolean("defaultVerifySsl");
+            logger.fine("Changed default verify SSL to: " + defaultVerifySsl);
         }
         save();
         return true;
@@ -85,6 +92,14 @@ public class ImageTagParameterConfiguration extends GlobalConfiguration {
     public void setDefaultTagOrdering(Ordering defaultTagOrdering) {
         logger.info("Changing default tag ordering to: " + defaultTagOrdering);
         this.defaultTagOrdering = defaultTagOrdering;
+        save();
+    }
+
+    @DataBoundSetter
+    @SuppressWarnings("unused")
+    public void setDefaultVerifySsl(Boolean defaultVerifySsl) {
+        logger.info("Changing default verify SSL to: " + defaultVerifySsl);
+        this.defaultVerifySsl = defaultVerifySsl;
         save();
     }
 

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -38,17 +38,18 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
     private final String credentialId;
     private String defaultTag;
     private Ordering tagOrder;
+    private Boolean verifySsl;
     private String errorMsg = "";
 
     @DataBoundConstructor
     @SuppressWarnings("unused")
     public ImageTagParameterDefinition(String name, String description, String image, String filter,
-                                       String registry, String credentialId) {
-        this(name, description, image, filter, "", registry, credentialId, config.getDefaultTagOrdering());
+                                       String registry, String credentialId, Boolean verifySsl) {
+        this(name, description, image, filter, "", registry, credentialId, config.getDefaultTagOrdering(), verifySsl);
     }
 
     public ImageTagParameterDefinition(String name, String description, String image, String filter, String defaultTag,
-                                       String registry, String credentialId, Ordering tagOrder) {
+                                       String registry, String credentialId, Ordering tagOrder, Boolean verifySsl) {
         super(name, description);
         this.image = image;
         this.registry = StringUtil.isNotNullOrEmpty(registry) ? registry : config.getDefaultRegistry();
@@ -56,6 +57,7 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
         this.defaultTag = StringUtil.isNotNullOrEmpty(defaultTag) ? defaultTag : "";
         this.credentialId = getDefaultOrEmptyCredentialId(this.registry, credentialId);
         this.tagOrder = tagOrder != null ? tagOrder : config.getDefaultTagOrdering();
+        this.verifySsl = verifySsl != null ? verifySsl : config.getDefaultVerifySsl();
     }
 
     public String getImage() {
@@ -94,6 +96,12 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
         this.tagOrder = tagOrder;
     }
 
+    public Boolean getVerifySsl() { return verifySsl; }
+
+    @DataBoundSetter
+    @SuppressWarnings("unused")
+    public void setVerifySsl(Boolean verifySsl) { this.verifySsl = verifySsl; }
+
     public String getErrorMsg() {
         return errorMsg;
     }
@@ -122,7 +130,7 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
             password = credential.getPassword().getPlainText();
         }
 
-        ResultContainer<List<String>> resultContainer = ImageTag.getTags(image, registry, filter, user, password, tagOrder);
+        ResultContainer<List<String>> resultContainer = ImageTag.getTags(image, registry, filter, user, password, tagOrder, verifySsl);
         Optional<String> optionalErrorMsg = resultContainer.getErrorMsg();
         if (optionalErrorMsg.isPresent()) {
             setErrorMsg(optionalErrorMsg.get());
@@ -161,7 +169,7 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
             ImageTagParameterValue value = (ImageTagParameterValue) defaultValue;
             return new ImageTagParameterDefinition(getName(), getDescription(),
                 getImage(), getFilter(), value.getImageTag(),
-                getRegistry(), getCredentialId(), getTagOrder());
+                getRegistry(), getCredentialId(), getTagOrder(), getVerifySsl());
         }
         return this;
     }
@@ -200,6 +208,9 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
         public Ordering getDefaultTagOrdering() {
             return config.getDefaultTagOrdering();
         }
+
+        @SuppressWarnings("unused")
+        public Boolean getDefaultVerifySsl() { return config.getDefaultVerifySsl(); }
 
         @SuppressWarnings("unused")
         public ListBoxModel doFillCredentialIdItems(@AncestorInPath Item context,

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterConfiguration/config.jelly
@@ -13,5 +13,9 @@
         <f:entry title="${%Default Tag Ordering}" field="defaultTagOrdering">
             <f:enum>${it}</f:enum>
         </f:entry>
+
+        <f:entry title="${%Default Verify SSL}" field="defaultVerifySsl">
+            <f:checkbox>${it}</f:checkbox>
+        </f:entry>
     </f:section>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterConfiguration/help-defaultVerifySsl.html
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterConfiguration/help-defaultVerifySsl.html
@@ -1,0 +1,3 @@
+<div>
+    Verify certificates for TLS connections to Docker registry
+</div>

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/config.jelly
@@ -27,6 +27,10 @@
             <f:textbox default="${descriptor.getDefaultRegistry()}" />
         </f:entry>
 
+        <f:entry title="${%Verify SSL}" field="verifySsl">
+            <f:checkbox default="${descriptor.getDefaultVerifySsl()}" />
+        </f:entry>
+
         <f:entry title="${%Registry Credential ID}" field="credentialId">
             <c:select default="${descriptor.getDefaultCredentialID()}" />
         </f:entry>

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/help-verifySsl.html
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/help-verifySsl.html
@@ -1,0 +1,3 @@
+<div>
+    Verify certificates for TLS connections to Docker registry
+</div>


### PR DESCRIPTION
Internally we run a Docker registry (that happens to be Artifactory) with self-signed certificates and as much as I'd like to use this image tag parameter plugin for some of our builds we stuck without being able to ignore certificate verification. This PR adds a boolean checkbox, defaulting to true, to the advanced options which gets passed through to the verifySsl configuration on each Unirest request