### PR TITLE
fix(ordering): In rare ocassions TagOrder was null and lead to unexpected behaviour

### DIFF
--- a/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
@@ -49,23 +49,23 @@ public class ImageTag {
         ResultContainer<List<String>> container = new ResultContainer<>(Collections.emptyList());
         logger.info("Ordering Tags according to: " + ordering);
 
-        if (ordering == Ordering.NATURAL || ordering == Ordering.REV_NATURAL) {
-            container.setValue(tags.stream()
-                .map(VersionNumber::toString)
-                .filter(tag -> tag.matches(filter))
-                .sorted(ordering == Ordering.NATURAL ? Collections.reverseOrder() : String::compareTo)
-                .collect(Collectors.toList()));
-        } else {
+        if (ordering == Ordering.DSC_VERSION || ordering == Ordering.ASC_VERSION) {
             try {
                 container.setValue(tags.stream()
-                    .filter(tag -> tag.toString().matches(filter))
-                    .sorted(ordering == Ordering.ASC_VERSION ? VersionNumber::compareTo : VersionNumber.DESCENDING)
-                    .map(VersionNumber::toString)
-                    .collect(Collectors.toList()));
+                   .filter(tag -> tag.toString().matches(filter))
+                   .sorted(ordering == Ordering.ASC_VERSION ? VersionNumber::compareTo : VersionNumber.DESCENDING)
+                   .map(VersionNumber::toString)
+                   .collect(Collectors.toList()));
             } catch (Exception ignore) {
                 logger.warning("Unable to cast ImageTags to versions! Versioned Ordering is not supported for this images tags.");
                 container.setErrorMsg("Unable to cast ImageTags to versions! Versioned Ordering is not supported for this images tags.");
             }
+        } else {
+            container.setValue(tags.stream()
+               .map(VersionNumber::toString)
+               .filter(tag -> tag.matches(filter))
+               .sorted(ordering == Ordering.NATURAL ? Collections.reverseOrder() : String::compareTo)
+               .collect(Collectors.toList()));
         }
 
         return container;

--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -85,7 +85,7 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
     }
 
     public Ordering getTagOrder() {
-        return tagOrder;
+        return tagOrder != null ? tagOrder : Ordering.NATURAL;
     }
 
     @DataBoundSetter
@@ -122,7 +122,8 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
             password = credential.getPassword().getPlainText();
         }
 
-        ResultContainer<List<String>> resultContainer = ImageTag.getTags(image, registry, filter, user, password, tagOrder);
+        ResultContainer<List<String>> resultContainer = ImageTag
+            .getTags(image, registry, filter, user, password, getTagOrder());
         Optional<String> optionalErrorMsg = resultContainer.getErrorMsg();
         if (optionalErrorMsg.isPresent()) {
             setErrorMsg(optionalErrorMsg.get());


### PR DESCRIPTION
This occurred with the changes proposed in #22 and showcased that the same can and does happen to TagOrder.
This fix guarantees that TagOrder will always be a valid `Ordering` value.

**Changes**

* add code to ensure TagOrder is never `null` once passed to `ImageTag` service
* reverse if expression for tag ordering

**Issue**

* TagOrder could be null in rare occasions and cause the wrong TagOrder to be applied