### PR TITLE
Handle AWS ECR credentials

### DIFF
--- a/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTag.java
@@ -127,9 +127,14 @@ public class ImageTag {
         String token = "";
 
         if (type.equals("Basic")) {
+          // The password from the AWS ECR Plugin already is converted to the basic auth token
+          if (user.equals("AWS")) {
+            return password;
+          } else {
             token = Base64.getEncoder().encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8));
 
             return token;
+          }
         }
 
         String realm = authService[1];


### PR DESCRIPTION
The AWS ECR Auth plugin https://github.com/jenkinsci/amazon-ecr-plugin, returns credentials already as a basic auth token. It is already base64'd and already has the username `AWS` in it.

A better detection would be to check if the class is `AmazonECSRegistryCredential` but I didn't want to add a dependency and I don't know a different way to do it (Java Noob).

Tested on:
Jenkins: 2.249.2
Java: 1.8.0_242-b08
amazon-ecr: 1.6
credentials: 2.3.13
aws-credentials: 1.28
aws-java-sdk: 1.11.854