### PR TITLE
Fetch multiple pages of image tags

### DIFF
--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -124,9 +124,9 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
 
         ResultContainer<List<String>> resultContainer = ImageTag
             .getTags(image, registry, filter, user, password, getTagOrder());
-        Optional<String> optionalErrorMsg = resultContainer.getErrorMsg();
+        Optional<List<String>> optionalErrorMsg = resultContainer.getErrorMsgs();
         if (optionalErrorMsg.isPresent()) {
-            setErrorMsg(optionalErrorMsg.get());
+            setErrorMsg(String.join("</br>", optionalErrorMsg.get()));
         } else {
             setErrorMsg("");
         }

--- a/src/main/java/io/jenkins/plugins/luxair/model/ResultContainer.java
+++ b/src/main/java/io/jenkins/plugins/luxair/model/ResultContainer.java
@@ -1,21 +1,30 @@
 package io.jenkins.plugins.luxair.model;
 
 import java.util.Optional;
+import java.util.List;
+import java.util.ArrayList;
 
 public class ResultContainer<V> {
-    private String errorMsg = null;
+    private List<String> errorMsgs = null;
     private V value;
 
     public ResultContainer(V defaultValue) {
         this.value = defaultValue;
     }
 
-    public void setErrorMsg(String errorMsg) {
-        this.errorMsg = errorMsg;
+    public void addErrorMsg(String errorMsg) {
+        if (this.errorMsgs == null) {
+            this.errorMsgs = new ArrayList<String>();
+        }
+        this.errorMsgs.add(errorMsg);
     }
 
-    public Optional<String> getErrorMsg() {
-        return Optional.ofNullable(errorMsg);
+    public Optional<List<String>> getErrorMsgs() {
+        return Optional.ofNullable(this.errorMsgs);
+    }
+
+    public void setErrorMsgs(List<String> errorMsgs) {
+        this.errorMsgs = errorMsgs;
     }
 
     public void setValue(V value) {


### PR DESCRIPTION
This utilizes Unirest's pagination fetcher to allow for fetching tags from multiple pages of results.

From what I can tell, the docker hub uses very long pages while Amazon's ECR uses 100 item pages.

The registry v2 API exposes pagination for images:
https://docs.docker.com/registry/spec/api/#pagination-1

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

I've installed and tested this on my local Jenkins instances against both ECR and primary docker hub. I'm not sure how to test it beyond that, but I'm happy to do so if someone can give me some pointers?