### PR TITLE
[CVE-2023-30516]  Ensure SSL verification is enabled by default on legacy configurations

### DIFF
--- a/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/luxair/ImageTagParameterDefinition.java
@@ -26,6 +26,7 @@ import org.kohsuke.stapler.*;
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -43,7 +44,7 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
     private String defaultTag;
     private Ordering tagOrder;
     private String errorMsg = "";
-    private boolean verifySsl = true;
+    private Boolean verifySsl = true;
 
     @DataBoundConstructor
     @SuppressWarnings("unused")
@@ -61,6 +62,13 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
         this.defaultTag = StringUtil.isNotNullOrEmpty(defaultTag) ? defaultTag : "";
         this.credentialId = getDefaultOrEmptyCredentialId(this.registry, credentialId);
         this.tagOrder = tagOrder != null ? tagOrder : config.getDefaultTagOrdering();
+    }
+
+    private Object readResolve() {
+        if (Objects.isNull(verifySsl)) {
+            setVerifySsl(true);
+        }
+        return this;
     }
 
     public String getImage() {
@@ -112,7 +120,7 @@ public class ImageTagParameterDefinition extends SimpleParameterDefinition {
 	}
 
     @DataBoundSetter
-    @SuppressWarnings("unused")    
+    @SuppressWarnings("unused")
 	public void setVerifySsl(boolean verifySsl) {
 		this.verifySsl = verifySsl;
 	}


### PR DESCRIPTION
Prior to this change, job configurations created before Image Tag Parameter Plugin 2.0 would silently disable SSL/TLS certificate validation when verifySsl was not present in the configuration XML. This is due to the use of a primitive boolean field with an initializer, which is ignored during XStream-based deserialization.

This change replaces the primitive field with a boxed Boolean and adds null-handling logic in `readResolve()` to ensure that SSL/TLS verification defaults to enabled (true) for legacy jobs that do not explicitly configure this field.

CVE-2023-30516 / SECURITY-2840

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
