### PR TITLE
Make the select input have the jenkins-input class

### DIFF
--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterDefinition/index.jelly
@@ -10,13 +10,11 @@
             <input type="hidden" name="description" value="${it.description}" />
             <input type="hidden" name="imageName" value="${it.image}" />
 
-            <select name="imageTag" style="min-width:18rem;">
+            <select name="imageTag" class="jenkins-input" style="min-width:18rem;">
                 <j:forEach var="aTag" items="${it.tags}" varStatus="loop">
-                    <j:choose>
-                        <f:option value="${aTag}" selected="${aTag.equals(it.defaultTag)}">
-                            ${it.image}:${aTag}
-                        </f:option>
-                    </j:choose>
+                    <f:option value="${aTag}" selected="${aTag.equals(it.defaultTag)}">
+                        ${it.image}:${aTag}
+                    </f:option>
                 </j:forEach>
             </select>
 

--- a/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterValue/value.jelly
+++ b/src/main/resources/io/jenkins/plugins/luxair/ImageTagParameterValue/value.jelly
@@ -1,9 +1,7 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
-	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
         <j:set var="escapeEntryTitleAndDescription" value="false" />
         <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
-		<f:textbox name="value" value="${it.value}" readonly="true" />
+		<f:textbox name="value" value="${it.value}"/>
 	</f:entry>
 </j:jelly>


### PR DESCRIPTION
The select input needs to have the "jenkins-input" class so that it can be styled.

### Testing done
Tested on localhost Jenkins instance.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
